### PR TITLE
fix: prevent setup workflow from editing/removing itself

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -31,13 +31,12 @@ jobs:
           echo "Renombrando: $OLD_NAME -> $NEW_NAME"
 
           if [ "$NEW_NAME" == "$OLD_NAME" ]; then
-            echo "El nombre ya es correcto. Borrando script..."
-            rm .github/workflows/setup.yml
+            echo "El nombre ya es correcto. No hay nada que renombrar."
             exit 0
           fi
 
           # 1. Reemplazo de contenido
-          grep -rl "$OLD_NAME" . --exclude-dir=.git --exclude=".github/workflows/setup.yml" | while read -r file ; do
+          grep -rl "$OLD_NAME" . --exclude-dir=.git --exclude=".github/workflows/setup.yml" --exclude=".github/workflows/setup.yaml" | while read -r file ; do
             sed -i "s/$OLD_NAME/$NEW_NAME/g" "$file"
           done
 
@@ -50,9 +49,6 @@ jobs:
             new_filename="${filename//$OLD_NAME/$NEW_NAME}"
             mv "$path" "$dir/$new_filename"
           done
-
-      - name: Eliminar este workflow
-        run: rm -f .github/workflows/setup.yml
 
       - name: Guardar cambios
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
### Motivation

- Evitar que el workflow de setup se auto-modifique o intente eliminarse durante el proceso de renombrado, lo que provocaba que el push automático fuera rechazado por falta del permiso `workflows` del token.

### Description

- Excluye explícitamente `.github/workflows/setup.yaml` del pase masivo `grep/sed` para que el archivo del workflow no sea modificado durante el renombrado.
- Elimina el step que intentaba borrar el workflow y cambia la salida cuando `NEW_NAME == OLD_NAME` para no tocar archivos de workflow.
- Mantiene la lógica de renombrado de contenidos y archivos/carpetas sin tocar `.github/workflows/*` para que el push del action funcione con el token existente.

### Testing

- Se verificó el diff de `.github/workflows/setup.yaml` mediante `git status --short && git diff -- .github/workflows/setup.yaml` y la salida mostró solo los cambios esperados, sin modificaciones de otros workflows.
- Se inspeccionó el contenido del archivo actualizado con `nl -ba .github/workflows/setup.yaml | sed -n '1,140p'` para validar las exclusiones y el mensaje no destructivo, y la verificación fue satisfactoria.
- El cambio de archivo se aplicó correctamente y las comprobaciones locales de estado finalizaron sin errores.