### PR TITLE
Harden CPR3D collision distance validation and fallback behavior

### DIFF
--- a/YotsubaEngine/Runtimes/CPR/CollisionPredictionRuntime3D.cs
+++ b/YotsubaEngine/Runtimes/CPR/CollisionPredictionRuntime3D.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using YotsubaEngine.Core.Component.C_3D;
 using YotsubaEngine.Core.Component.C_AGNOSTIC;
 using YotsubaEngine.Core.Entity;
+#if YTB
+using YotsubaEngine.Core.System.YotsubaEngineUI;
+#endif
 using YotsubaEngine.Core.YotsubaGame;
 using YotsubaEngine.HighestPerformanceTypes;
 using YotsubaEngine.Runtime.CPR.Events;
@@ -30,10 +34,13 @@ namespace YotsubaEngine.Runtime.CPR
 
         public Dictionary<Point3, YTB<int>> SpatialHashGrid;
         private Dictionary<int, Point3> EntityPoint;
+        private const int SafeCollisionDistance = 1;
         private static int unPhysicalCollisionDistance;
 
         public override void InitializeSystem(EntityManager entityManager)
         {
+            EnsureValidCollisionDistance("InitializeSystem");
+
             SpatialGridStorage = new(500);
             SpatialHashGrid = new Dictionary<Point3, YTB<int>>();
             EntityPoint = new Dictionary<int, Point3>();
@@ -199,11 +206,44 @@ namespace YotsubaEngine.Runtime.CPR
 
         private Point3 GetSpatialHash(ref TransformComponent transform)
         {
+            int divisor = EnsureValidCollisionDistance("GetSpatialHash");
+
+#if DEBUG
+            Debug.Assert(divisor > 0, "[CPR3D] UnPhysicalCollisionDistance must always be > 0 before cell division.");
+#endif
+
             return new(
-                  ((int)(transform.Position.X / UnPhysicalCollisionDistance)),
-                  ((int)(transform.Position.Y / UnPhysicalCollisionDistance)),
-                  ((int)(transform.Position.Z / UnPhysicalCollisionDistance))
+                  ((int)(transform.Position.X / divisor)),
+                  ((int)(transform.Position.Y / divisor)),
+                  ((int)(transform.Position.Z / divisor))
             );
+        }
+
+        /// <summary>
+        /// Garantiza que el divisor de celdas sea válido antes de cualquier cálculo espacial.
+        /// Si la configuración es inválida (<= 0), aplica fallback determinista (=1) y emite warning en Debug/YTB.
+        /// </summary>
+        private static int EnsureValidCollisionDistance(string context)
+        {
+            int configuredValue = unPhysicalCollisionDistance;
+            if (configuredValue > 0)
+                return configuredValue;
+
+            unPhysicalCollisionDistance = SafeCollisionDistance;
+            EmitInvalidDistanceWarning(configuredValue, SafeCollisionDistance, context);
+            return SafeCollisionDistance;
+        }
+
+        [Conditional("DEBUG")]
+        private static void EmitInvalidDistanceWarning(int receivedValue, int fallbackValue, string context)
+        {
+            string message = $"[CPR3D][Warning] UnPhysicalCollisionDistance inválido ({receivedValue}) en {context}. " +
+                             $"Aplicando fallback determinista: {fallbackValue}.";
+#if YTB
+            EngineUISystem.SendLog(message);
+#else
+            Debug.WriteLine(message);
+#endif
         }
 
         public override void Dispose()


### PR DESCRIPTION
### Motivation
- Evitar divisiones por un divisor inválido en el cálculo de celdas espaciales que pueden producir comportamientos indeterminados o excepciones.
- Mantener el comportamiento por defecto seguro (`1`) pero asegurar que cualquier configuración inválida sea normalizada en tiempo de inicialización y justo antes de usarla. 
- Proveer trazabilidad y una verificación no-GPU para comprobar que valores inválidos nunca alcanzan la operación de división.

### Description
- Se añadió la constante `SafeCollisionDistance = 1` y la función `EnsureValidCollisionDistance(string context)` para validar y normalizar `unPhysicalCollisionDistance` cuando sea `<= 0` y devolver un divisor seguro.
- `InitializeSystem` ahora invoca `EnsureValidCollisionDistance("InitializeSystem")` para normalizar la configuración antes de poblar la cuadrícula espacial, y `GetSpatialHash` usa el `divisor` validado en lugar de usar `unPhysicalCollisionDistance` directamente.
- Se añadió `EmitInvalidDistanceWarning` (emitido bajo `DEBUG`) que registra un warning con contexto, valor recibido y fallback aplicado usando `EngineUISystem.SendLog` cuando `YTB` está activo, o `Debug.WriteLine` en otros entornos.
- Se agregó una aserción `Debug.Assert(divisor > 0, ...)` en `GetSpatialHash` y documentación XML que explica el comportamiento determinista ante configuración inválida.

### Testing
- Se agregó una aserción de depuración (`Debug.Assert`) como guard no-GPU verificable para garantizar en tiempo de ejecución Debug que no se realiza la división con un divisor inválido; esto actúa como la prueba/aseveración solicitada.
- Intento de compilación automática con `dotnet build YotsubaEngine/YotsubaEngine.csproj -c Debug` falló en este entorno porque el SDK no está disponible (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f850184f08332b09c27aa9c55a4c1)