### PR TITLE
Implementar flujos de eliminación y UnregisterEntity para CPR/RPR 3D

### DIFF
--- a/YotsubaEngine/Core/YotsubaGame/EntityManager.cs
+++ b/YotsubaEngine/Core/YotsubaGame/EntityManager.cs
@@ -410,6 +410,51 @@ namespace YotsubaEngine.Core.YotsubaGame
             YtbModelComponents[(uint)entity.Id] = component;
             EventManager.Instance.Publish<OnEntityYTBModelIsAdded>(new OnEntityYTBModelIsAdded(entity));
         }
+
+        public void RemoveEntity(int entityId)
+        {
+            EventManager.Instance.Publish<OnEntityRemoved>(new(entityId));
+        }
+
+        public void RemoveTransformComponent(int entityId)
+        {
+            YotsubaEntities[entityId].RemoveComponent(YTBComponent.Transform);
+            EventManager.Instance.Publish<OnEntityTransformIsRemoved>(new(entityId));
+        }
+
+        public void RemoveRigidbody3DComponent(int entityId)
+        {
+            YotsubaEntities[entityId].RemoveComponent(YTBComponent.Rigibody3D);
+            EventManager.Instance.Publish<OnEntityRigidBody3DIsRemoved>(new(entityId));
+        }
+
+        public void RemoveModelComponent3D(int entityId)
+        {
+            YotsubaEntities[entityId].RemoveComponent(YTBComponent.Model3D);
+            EventManager.Instance.Publish<OnEntityModelComponentIsRemoved>(new(entityId));
+        }
+
+        public void RemoveYTBObject3D(int entityId)
+        {
+            YotsubaEntities[entityId].RemoveComponent(YTBComponent.YTBModel3D);
+            EventManager.Instance.Publish<OnEntityYTBModelIsRemoved>(new(entityId));
+        }
+
+        public void RemoveSpriteComponent(int entityId)
+        {
+            YotsubaEntities[entityId].RemoveComponent(YTBComponent.Sprite);
+            EventManager.Instance.Publish<OnEntitySpriteIsRemoved>(new(entityId));
+        }
+
+        public void SetSprite2_5D(int entityId, bool is2_5D)
+        {
+            ref SpriteComponent2D sprite = ref Sprite2DComponents[entityId];
+            bool previous = sprite.Is2_5D;
+            sprite.Is2_5D = is2_5D;
+            if (is2_5D && !previous) EventManager.Instance.Publish<OnSpriteIsSettedAs2_5D>(new());
+            else if (!is2_5D && previous) EventManager.Instance.Publish<OnSpriteNoLonger2_5D>(new(entityId));
+        }
+
     }
 }
 

--- a/YotsubaEngine/Runtimes/CPR/CollisionPredictionRuntime3D.cs
+++ b/YotsubaEngine/Runtimes/CPR/CollisionPredictionRuntime3D.cs
@@ -64,6 +64,9 @@ namespace YotsubaEngine.Runtime.CPR
 
             EventManager.Instance.Subscribe<OnEntityRigidBody3DIsAdded>(EntityAdd);
             EventManager.Instance.Subscribe<OnEntityTransformIsAdded>(EntityAdd);
+            EventManager.Instance.Subscribe<OnEntityRemoved>(EntityRemoved);
+            EventManager.Instance.Subscribe<OnEntityTransformIsRemoved>(EntityComponentRemoved);
+            EventManager.Instance.Subscribe<OnEntityRigidBody3DIsRemoved>(EntityComponentRemoved);
         }
 
         public YTB<int> IsPhysicalPossibleCollide(ref TransformComponent transformComponent, int entityId, YTB<int> entitiesCanCollide)
@@ -152,6 +155,21 @@ namespace YotsubaEngine.Runtime.CPR
                 RegisterEntity(added.Entity.Id);
         }
 
+        private void EntityRemoved(OnEntityRemoved removed)
+        {
+            UnregisterEntity(removed.EntityId);
+        }
+
+        private void EntityComponentRemoved(OnEntityTransformIsRemoved removed)
+        {
+            UnregisterEntity(removed.EntityId);
+        }
+
+        private void EntityComponentRemoved(OnEntityRigidBody3DIsRemoved removed)
+        {
+            UnregisterEntity(removed.EntityId);
+        }
+
         private void RegisterEntity(int entityId)
         {
             bool alreadyRegistered = false;
@@ -197,6 +215,29 @@ namespace YotsubaEngine.Runtime.CPR
             EntityPoint[entityId] = point;
         }
 
+
+
+        private void UnregisterEntity(int entityId)
+        {
+            Entities.RemoveFast(entityId);
+
+            if (EntityPoint.TryGetValue(entityId, out Point3 point))
+            {
+                if (SpatialHashGrid.TryGetValue(point, out YTB<int> list))
+                {
+                    list.RemoveFast(entityId);
+                    if (list.Count == 0)
+                    {
+                        SpatialHashGrid.Remove(point);
+                        list.Clear();
+                        SpatialGridStorage.Return(list);
+                    }
+                }
+
+                EntityPoint.Remove(entityId);
+            }
+        }
+
         private Point3 GetSpatialHash(ref TransformComponent transform)
         {
             return new(
@@ -211,6 +252,18 @@ namespace YotsubaEngine.Runtime.CPR
             DistanceIsSetted = false;
             EventManager.Instance.Unsubscribe<OnEntityRigidBody3DIsAdded>(EntityAdd);
             EventManager.Instance.Unsubscribe<OnEntityTransformIsAdded>(EntityAdd);
+            EventManager.Instance.Unsubscribe<OnEntityRemoved>(EntityRemoved);
+            EventManager.Instance.Unsubscribe<OnEntityTransformIsRemoved>(EntityComponentRemoved);
+            EventManager.Instance.Unsubscribe<OnEntityRigidBody3DIsRemoved>(EntityComponentRemoved);
+
+            foreach (var kv in SpatialHashGrid)
+            {
+                kv.Value.Clear();
+                SpatialGridStorage.Return(kv.Value);
+            }
+            SpatialHashGrid.Clear();
+            EntityPoint.Clear();
+            Entities.Clear();
             base.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/YotsubaEngine/Runtimes/CPR/Events/OnEntityRigidBody3DIsRemoved.cs
+++ b/YotsubaEngine/Runtimes/CPR/Events/OnEntityRigidBody3DIsRemoved.cs
@@ -1,0 +1,4 @@
+namespace YotsubaEngine.Runtime.CPR.Events
+{
+    internal readonly record struct OnEntityRigidBody3DIsRemoved(int EntityId);
+}

--- a/YotsubaEngine/Runtimes/CPR/Events/OnEntityTransformIsRemoved.cs
+++ b/YotsubaEngine/Runtimes/CPR/Events/OnEntityTransformIsRemoved.cs
@@ -1,0 +1,4 @@
+namespace YotsubaEngine.Runtime.CPR.Events
+{
+    internal readonly record struct OnEntityTransformIsRemoved(int EntityId);
+}

--- a/YotsubaEngine/Runtimes/RPR/Events/OnEntityModelComponentIsRemoved.cs
+++ b/YotsubaEngine/Runtimes/RPR/Events/OnEntityModelComponentIsRemoved.cs
@@ -1,0 +1,4 @@
+namespace YotsubaEngine.Runtime.RPR.Events
+{
+    internal readonly record struct OnEntityModelComponentIsRemoved(int EntityId);
+}

--- a/YotsubaEngine/Runtimes/RPR/Events/OnEntityRemoved.cs
+++ b/YotsubaEngine/Runtimes/RPR/Events/OnEntityRemoved.cs
@@ -1,0 +1,4 @@
+namespace YotsubaEngine.Runtime.RPR.Events
+{
+    internal readonly record struct OnEntityRemoved(int EntityId);
+}

--- a/YotsubaEngine/Runtimes/RPR/Events/OnEntitySpriteIsRemoved.cs
+++ b/YotsubaEngine/Runtimes/RPR/Events/OnEntitySpriteIsRemoved.cs
@@ -1,0 +1,4 @@
+namespace YotsubaEngine.Runtime.RPR.Events
+{
+    internal readonly record struct OnEntitySpriteIsRemoved(int EntityId);
+}

--- a/YotsubaEngine/Runtimes/RPR/Events/OnEntityYTBModelIsRemoved.cs
+++ b/YotsubaEngine/Runtimes/RPR/Events/OnEntityYTBModelIsRemoved.cs
@@ -1,0 +1,4 @@
+namespace YotsubaEngine.Runtime.RPR.Events
+{
+    internal readonly record struct OnEntityYTBModelIsRemoved(int EntityId);
+}

--- a/YotsubaEngine/Runtimes/RPR/Events/OnSpriteNoLonger2_5D.cs
+++ b/YotsubaEngine/Runtimes/RPR/Events/OnSpriteNoLonger2_5D.cs
@@ -1,0 +1,4 @@
+namespace YotsubaEngine.Runtime.RPR.Events
+{
+    internal readonly record struct OnSpriteNoLonger2_5D(int EntityId);
+}

--- a/YotsubaEngine/Runtimes/RPR/RenderPredictionRuntime3D.cs
+++ b/YotsubaEngine/Runtimes/RPR/RenderPredictionRuntime3D.cs
@@ -54,6 +54,12 @@ namespace YotsubaEngine.Runtime.RPR
             EventManager.Instance.Subscribe<OnEntityModelComponentIsAdded>(EntityAdd);
             EventManager.Instance.Subscribe<OnEntityYTBModelIsAdded>(EntityAdd);
             EventManager.Instance.Subscribe<OnSpriteIsSettedAs2_5D>(EntityAdd);
+            EventManager.Instance.Subscribe<OnEntityRemoved>(EntityRemoved);
+            EventManager.Instance.Subscribe<OnEntityTransformIsRemoved>(EntityComponentRemoved);
+            EventManager.Instance.Subscribe<OnEntityModelComponentIsRemoved>(EntityComponentRemoved);
+            EventManager.Instance.Subscribe<OnEntityYTBModelIsRemoved>(EntityComponentRemoved);
+            EventManager.Instance.Subscribe<OnSpriteNoLonger2_5D>(EntityComponentRemoved);
+            EventManager.Instance.Subscribe<OnEntitySpriteIsRemoved>(EntityComponentRemoved);
         }
 
         private void EntityAdd(OnSpriteIsSettedAs2_5D d)
@@ -73,6 +79,17 @@ namespace YotsubaEngine.Runtime.RPR
                 }
             }
         }
+
+        private void EntityRemoved(OnEntityRemoved removed)
+        {
+            UnregisterEntity(removed.EntityId);
+        }
+
+        private void EntityComponentRemoved(OnEntityTransformIsRemoved removed) => UnregisterEntity(removed.EntityId);
+        private void EntityComponentRemoved(OnEntityModelComponentIsRemoved removed) => UnregisterEntity(removed.EntityId);
+        private void EntityComponentRemoved(OnEntityYTBModelIsRemoved removed) => UnregisterEntity(removed.EntityId);
+        private void EntityComponentRemoved(OnSpriteNoLonger2_5D removed) => UnregisterEntity(removed.EntityId);
+        private void EntityComponentRemoved(OnEntitySpriteIsRemoved removed) => UnregisterEntity(removed.EntityId);
 
         private void EntityAdd(OnEntityYTBModelIsAdded added)
         {
@@ -115,12 +132,24 @@ namespace YotsubaEngine.Runtime.RPR
             }
         }
 
+        private void UnregisterEntity(int entityId)
+        {
+            Entities.RemoveFast(entityId);
+        }
+
         public override void Dispose()
         {
             EventManager.Instance.Unsubscribe<OnEntityModelComponentIsAdded>(EntityAdd);
             EventManager.Instance.Unsubscribe<OnEntityTransformIsAdded>(EntityAdd);
             EventManager.Instance.Unsubscribe<OnEntityYTBModelIsAdded>(EntityAdd);
             EventManager.Instance.Unsubscribe<OnSpriteIsSettedAs2_5D>(EntityAdd);
+            EventManager.Instance.Unsubscribe<OnEntityRemoved>(EntityRemoved);
+            EventManager.Instance.Unsubscribe<OnEntityTransformIsRemoved>(EntityComponentRemoved);
+            EventManager.Instance.Unsubscribe<OnEntityModelComponentIsRemoved>(EntityComponentRemoved);
+            EventManager.Instance.Unsubscribe<OnEntityYTBModelIsRemoved>(EntityComponentRemoved);
+            EventManager.Instance.Unsubscribe<OnSpriteNoLonger2_5D>(EntityComponentRemoved);
+            EventManager.Instance.Unsubscribe<OnEntitySpriteIsRemoved>(EntityComponentRemoved);
+            Entities.Clear();
             GC.SuppressFinalize(this);
             base.Dispose();
         }

--- a/YotsubaEngine/Runtimes/RuntimeRemovalDebugCase.cs
+++ b/YotsubaEngine/Runtimes/RuntimeRemovalDebugCase.cs
@@ -1,0 +1,40 @@
+using System;
+using YotsubaEngine.Core.Component.C_2D;
+using YotsubaEngine.Core.Component.C_3D;
+using YotsubaEngine.Core.Component.C_AGNOSTIC;
+using YotsubaEngine.Core.Entity;
+using YotsubaEngine.Core.YotsubaGame;
+using YotsubaEngine.Runtime.CPR;
+using YotsubaEngine.Runtime.RPR;
+
+namespace YotsubaEngine.Runtimes
+{
+    internal static class RuntimeRemovalDebugCase
+    {
+        internal static bool ValidateRemovedIdsAreNotPersisted()
+        {
+            EntityManager manager = new();
+            Yotsuba a = new(0);
+            manager.AddEntity(ref a);
+            manager.AddTransformComponent(a, new TransformComponent());
+            manager.AddRigidbody3DComponent(a, new RigidBodyComponent3D());
+            manager.AddModelComponent3D(a, new ModelComponent3D());
+
+            var cpr = new Collision_Prediction_Runtime_3D();
+            cpr.InitializeSystem(manager);
+            var rpr = new Render_Prediction_Runtime_3D();
+            rpr.InitializeSystem(manager);
+
+            manager.RemoveRigidbody3DComponent(a.Id);
+            manager.SetSprite2_5D(a.Id, false);
+            manager.RemoveModelComponent3D(a.Id);
+
+            bool removedFromCPR = !cpr.Entities.AsReadOnlySpan().Contains(a.Id);
+            bool removedFromRPR = !rpr.GetEntitieIdsCanRender3D().Contains(a.Id);
+
+            cpr.Dispose();
+            rpr.Dispose();
+            return removedFromCPR && removedFromRPR;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Evitar que IDs de entidades y estado runtime (CPR/RPR) persistan tras eliminación de entidades o remoción de componentes y evitar residuos entre escenas/reloads. 
- Hacer que los runtimes 3D reaccionen de forma desacoplada a cambios de estado (remoción de entidad/Transform/Rigidbody3D/Model3D/YTBModel3D/Sprite y cambio de Is2_5D). 

### Description
- Implementé `UnregisterEntity(int entityId)` en `YotsubaEngine/Runtimes/CPR/CollisionPredictionRuntime3D.cs` para remover el ID de `Entities`, extraerlo de `SpatialHashGrid` usando `EntityPoint`, limpiar celdas vacías devolviendo las listas al pool y borrar la entrada en `EntityPoint`, y suscribí handlers a eventos de removido. 
- Implementé `UnregisterEntity(int entityId)` en `YotsubaEngine/Runtimes/RPR/RenderPredictionRuntime3D.cs` y conecté la lógica a los eventos relevantes para quitar entidades cuando dejan de cumplir requisitos de render 3D. 
- Añadí eventos de removido (`record struct` en `Runtimes/CPR/Events` y `Runtimes/RPR/Events`) y nuevos métodos en `YotsubaEngine/Core/YotsubaGame/EntityManager.cs` que eliminan componentes/publican eventos para los casos solicitados (entidad, Transform, Rigidbody3D, Model3D, YTBModel3D, Sprite y cambio Is2_5D). 
- Reforcé la limpieza en los `Dispose` de los runtimes para limpiar estructuras internas (pools, diccionarios y listas) y evitar residuos entre escenas. 
- Añadí un caso de verificación/debug (`YotsubaEngine/Runtimes/RuntimeRemovalDebugCase.cs`) que valida que los IDs removidos no persisten en CPR/RPR (función `ValidateRemovedIdsAreNotPersisted`). 

### Testing
- Ejecuté `dotnet build -v minimal` en este entorno y la ejecución falló por limitación del entorno con el error `dotnet: command not found`. 
- No se ejecutaron otros tests automatizados en esta sesión debido a la falta del SDK; se incluyó un caso de verificación local en código pero no fue ejecutado aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f85055900833294fc447efc6cb439)