### PR TITLE
Add per-frame OCR/RPR instrumentation, depth-ready check and OCR ON/OFF switch

### DIFF
--- a/YotsubaEngine/Core/System/S_3D/RenderSystem3D.cs
+++ b/YotsubaEngine/Core/System/S_3D/RenderSystem3D.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Diagnostics;
 using YotsubaEngine.Core.Component.C_2D;
 using YotsubaEngine.Core.Component.C_3D;
 using YotsubaEngine.Core.Component.C_AGNOSTIC;
@@ -35,6 +36,9 @@ namespace YotsubaEngine.Core.System.S_3D
 
         private Hardware_Occlusion_Querie_Runtime HardwareOcclusionQuerieRuntime;
 
+        public void SetOcclusionCullingEnabled(bool enabled)
+            => HardwareOcclusionQuerieRuntime.UseOcrCulling = enabled;
+
         /// <summary>
         /// Inicializa el sistema de renderizado 3D.
         /// <para>Initializes the 3D render system.</para>
@@ -68,6 +72,12 @@ namespace YotsubaEngine.Core.System.S_3D
                 if (GameWontRun.GameWontRunByException) return;
 #endif
             //+:cnd:noEmit
+
+            bool depthReadyForOcclusion = ReferenceEquals(YTBGlobalState.GraphicsDevice.DepthStencilState, DepthStencilState.Default);
+            Debug.WriteLine($"[Render3D] DepthReadyBeforeOcrQuery={depthReadyForOcclusion}");
+#if YTB
+            EngineUISystem.SendLog($"[Render3D] DepthReadyBeforeOcrQuery={depthReadyForOcclusion}");
+#endif
 
             Span<int> entities = HardwareOcclusionQuerieRuntime.GetEntitiesToRender();
             Span<Yotsuba> Yotsubas = GetEntitiesAsSpan();

--- a/YotsubaEngine/Runtimes/OCR/HardwareOcclusionQuerieRuntime.cs
+++ b/YotsubaEngine/Runtimes/OCR/HardwareOcclusionQuerieRuntime.cs
@@ -1,6 +1,8 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Diagnostics;
+using System.Text;
 using YotsubaEngine.Core.Component.C_3D;
 using YotsubaEngine.Core.Component.C_AGNOSTIC;
 using YotsubaEngine.Core.Entity;
@@ -13,6 +15,19 @@ namespace YotsubaEngine.Runtime.OCR
 {
     public class Hardware_Occlusion_Querie_Runtime : YTB_Runtime
     {
+    public readonly struct OcclusionInstrumentationFrame
+    {
+        public int FrameIndex { get; init; }
+        public int RprPredictedCount { get; init; }
+        public int OcrVisibleCount { get; init; }
+        public int OcrOccludedCount { get; init; }
+        public int OcclusionTransitionsCount { get; init; }
+        public int PendingQueriesCount { get; init; }
+
+        public string ToLogLine()
+            => $"[OCR][Frame {FrameIndex}] RPR={RprPredictedCount} OCR Visible={OcrVisibleCount} Occluded={OcrOccludedCount} PendingQueries={PendingQueriesCount} IsOccludedTransitions={OcclusionTransitionsCount}";
+    }
+
         private Render_Prediction_Runtime_3D RenderPredictionRuntime3D;
 
         private Graphics3D Graphics3D;
@@ -23,6 +38,12 @@ namespace YotsubaEngine.Runtime.OCR
         };
 
         private YTB<int> EntityToReturn { get; set; } 
+        private int _frameIndex;
+        private readonly StringBuilder _transitionLogBuilder = new();
+
+        public bool InstrumentationEnabled { get; set; } = true;
+        public bool UseOcrCulling { get; set; } = true;
+        public OcclusionInstrumentationFrame LastFrameInstrumentation { get; private set; }
         public override void InitializeSystem(EntityManager entities)
         {
             EntityManager = entities;
@@ -61,6 +82,12 @@ namespace YotsubaEngine.Runtime.OCR
             gd.DepthStencilState = DepthStencilState.Default;
 
             Span<int> entitiesSpan = RenderPredictionRuntime3D.GetEntitieIdsCanRender3D();
+            int visibleCount = 0;
+            int occludedCount = 0;
+            int transitions = 0;
+            int pendingQueries = 0;
+            _transitionLogBuilder.Clear();
+            _frameIndex++;
             foreach (int entityId in entitiesSpan)
             {
                 ref Yotsuba entity = ref GlobalEntities[entityId];
@@ -68,10 +95,12 @@ namespace YotsubaEngine.Runtime.OCR
                 if(entity.HasNotComponent(YTBComponent.Model3D))
                 {
                     visibility.Add(entityId);
+                    continue;
                 }
 
                 ref TransformComponent transform = ref transformComponents[entityId];
                 ref ModelComponent3D model = ref modelComponents[entityId];
+                bool previousOccludedState = model.IsOccluded;
 
                 // 1. Matriz de Mundo Cacheada
                 float yaw = MathHelper.ToRadians(transform.Rotation);
@@ -99,10 +128,21 @@ namespace YotsubaEngine.Runtime.OCR
                         model.IsQueryActive = false;
                     }
 
-                    // 4. AÑADIR A LISTA DE VISIBLES
-                    if (!model.IsOccluded)
+                    if (previousOccludedState != model.IsOccluded)
                     {
+                        transitions++;
+                        _transitionLogBuilder.Append($" entityId={entityId}:{previousOccludedState}->{model.IsOccluded};");
+                    }
+
+                    // 4. AÑADIR A LISTA DE VISIBLES
+                    if (!UseOcrCulling || !model.IsOccluded)
+                    {
+                        visibleCount++;
                         visibility.Add(entityId);
+                    }
+                    else
+                    {
+                        occludedCount++;
                     }
 
                     // 5. INICIAR NUEVA PRUEBA (Dibujar caja invisible a la GPU)
@@ -121,12 +161,38 @@ namespace YotsubaEngine.Runtime.OCR
                         model.IsQueryActive = true;
                         model.IsOccluded = false; // Prevención de popping
                     }
+                    else
+                    {
+                        pendingQueries++;
+                    }
                 }
             }
 
             // Restaurar estados originales de la GPU
             gd.BlendState = oldBlendState;
             gd.DepthStencilState = oldDepthStencil;
+
+            LastFrameInstrumentation = new OcclusionInstrumentationFrame
+            {
+                FrameIndex = _frameIndex,
+                RprPredictedCount = entitiesSpan.Length,
+                OcrVisibleCount = visibleCount,
+                OcrOccludedCount = occludedCount,
+                OcclusionTransitionsCount = transitions,
+                PendingQueriesCount = pendingQueries
+            };
+
+            if (InstrumentationEnabled)
+            {
+                Debug.WriteLine(LastFrameInstrumentation.ToLogLine());
+#if YTB
+                YotsubaEngine.Core.System.YotsubaEngineUI.EngineUISystem.SendLog(LastFrameInstrumentation.ToLogLine());
+                if (_transitionLogBuilder.Length > 0)
+                {
+                    YotsubaEngine.Core.System.YotsubaEngineUI.EngineUISystem.SendLog($"[OCR][Frame {_frameIndex}] Transitions:{_transitionLogBuilder}");
+                }
+#endif
+            }
 
             return visibility;
         }

--- a/docs/ocr_rpr_validation_checklist.md
+++ b/docs/ocr_rpr_validation_checklist.md
@@ -1,0 +1,29 @@
+# OCR/RPR Validation Checklist (Issue #109)
+
+## Escenario controlado
+1. Ejecutar la misma escena/cámara por al menos 300 frames con OCR **desactivado** (`RenderSystem3D.SetOcclusionCullingEnabled(false)`).
+2. Repetir exactamente la corrida con OCR **activado** (`RenderSystem3D.SetOcclusionCullingEnabled(true)`).
+3. Comparar líneas de instrumentación por frame:
+   - `[Render3D] DepthReadyBeforeOcrQuery=...`
+   - `[OCR][Frame N] RPR=... OCR Visible=... Occluded=... PendingQueries=... IsOccludedTransitions=...`
+
+## Criterios de aceptación medibles
+- **Pass order/depth listo:** `DepthReadyBeforeOcrQuery=true` en >= 99% de los frames.
+- **Diferencia funcional OCR OFF vs ON:**
+  - OCR OFF: `OCR Visible == RPR` en >= 99% de los frames.
+  - OCR ON: existe al menos un frame con `OCR Occluded > 0` en escena con oclusores.
+- **Transiciones válidas de estado:** al menos una transición `false->true` y `true->false` para una entidad cuando atraviesa oclusión/visibilidad.
+- **Estabilidad:** sin exceptions durante 300 frames en configuraciones `YTB`, `Debug`, `Release`.
+- **Consistencia cross-config:** diferencia de conteos por frame entre configuraciones <= 1 entidad para la misma escena/cámara semilla.
+
+## Registro recomendado
+Guardar logs por configuración:
+- `logs/ocr_ytb.log`
+- `logs/ocr_debug.log`
+- `logs/ocr_release.log`
+
+y adjuntar tabla comparativa:
+- promedio `RPR`
+- promedio `OCR Visible`
+- promedio `OCR Occluded`
+- total de transiciones `IsOccluded`


### PR DESCRIPTION
### Motivation
- Add deterministic, frame-level metrics to validate hardware occlusion queries (OCR) against render prediction (RPR) and to diagnose pass-order/depth issues introduced in #109. 
- Provide a controlled A/B scenario (OCR on vs off) and measurable acceptance criteria so the issue can be closed with quantitative evidence.

### Description
- Instrumented `Hardware_Occlusion_Querie_Runtime` to record a per-frame `OcclusionInstrumentationFrame` with `RprPredictedCount`, `OcrVisibleCount`, `OcrOccludedCount`, `PendingQueriesCount` and `OcclusionTransitionsCount`, and expose it as `LastFrameInstrumentation` while emitting `Debug.WriteLine` and `EngineUISystem.SendLog` (under `#if YTB`).
- Track `IsOccluded` transitions per `entityId` and record a human-readable transition log for frames with changes, and count pending queries to surface pipeline latency.
- Added `UseOcrCulling` flag and a `RenderSystem3D.SetOcclusionCullingEnabled(bool)` method to run controlled OCR OFF/ON comparisons; the OCR runtime respects `UseOcrCulling` when deciding whether to hide occluded entities.
- Added a depth-readiness check in `RenderSystem3D.Render3D` that logs `DepthReadyBeforeOcrQuery` just before calling the OCR runtime to validate that the depth buffer/ pass order is correct prior to issuing occlusion queries, and created `docs/ocr_rpr_validation_checklist.md` with measurable acceptance criteria and an A/B test procedure.
- Fixed a logic flow issue by explicitly `continue`-ing when an entity lacks a `Model3D` after adding it to visibility, avoiding further model access.

### Testing
- Attempted automated build with `dotnet build YotsubaEngine/YotsubaEngine.csproj -c Debug`, but the environment lacks `dotnet` and the build could not be executed (`dotnet: command not found`).
- Performed repository-level inspections and file edits to validate changes were written; changes committed locally and a PR description was staged via the repo tooling.  No compilation or runtime tests were run due to the missing SDK in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f850a014c8332b3912966be5aea4b)